### PR TITLE
feat: add storage management CLI commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
       "devDependencies": {
         "@babel/preset-env": "^7.23.2",
         "@babel/preset-typescript": "^7.21.4",
-        "@types/cli-spinner": "^0.2.1",
+        "@types/cli-spinner": "^0.2.3",
         "@types/fs-extra": "^11.0.1",
         "@types/jest": "^29.5.0",
         "@types/mime-types": "^2.1.1",
@@ -2971,6 +2971,7 @@
       "resolved": "https://registry.npmjs.org/@types/cli-spinner/-/cli-spinner-0.2.3.tgz",
       "integrity": "sha512-TMO6mWltW0lCu1de8DMRq9+59OP/tEjghS+rs8ZEQ2EgYP5yV3bGw0tS14TMyJGqFaoVChNvhkVzv9RC1UgX+w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -3910,6 +3911,7 @@
       "version": "0.2.10",
       "resolved": "https://registry.npmjs.org/cli-spinner/-/cli-spinner-0.2.10.tgz",
       "integrity": "sha512-U0sSQ+JJvSLi1pAYuJykwiA8Dsr15uHEy85iCJ6A+0DjVxivr3d+N2Wjvodeg89uP5K6TswFkKBfAD7B3YSn/Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10"
       }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@babel/preset-env": "^7.23.2",
     "@babel/preset-typescript": "^7.21.4",
-    "@types/cli-spinner": "^0.2.1",
+    "@types/cli-spinner": "^0.2.3",
     "@types/fs-extra": "^11.0.1",
     "@types/jest": "^29.5.0",
     "@types/mime-types": "^2.1.1",

--- a/src/Commands/bandwidth-usage.ts
+++ b/src/Commands/bandwidth-usage.ts
@@ -1,0 +1,38 @@
+import { yellow, red } from 'kleur'
+import { Spinner } from 'cli-spinner'
+import lighthouse from '../Lighthouse'
+import byteToSize from './utils/byteToSize'
+import { config } from './utils/getNetwork'
+
+export default async function (data: any, options: any) {
+  try {
+    if (!config.get('LIGHTHOUSE_GLOBAL_API_KEY')) {
+      throw new Error('API key not found. Please set up your API key first.')
+    }
+
+    const spinner = new Spinner('Fetching bandwidth usage... %s')
+    spinner.start()
+
+    const uploadsResponse = await lighthouse.getUploads(
+      config.get('LIGHTHOUSE_GLOBAL_API_KEY') as string
+    )
+
+    spinner.stop()
+    process.stdout.clearLine(-1, () => {})
+    process.stdout.cursorTo(0)
+
+    const totalDownloads = uploadsResponse.data.fileList.reduce((acc: number, file: any) => acc + (file.downloadCount || 0), 0)
+    const totalBandwidth = uploadsResponse.data.fileList.reduce((acc: number, file: any) => 
+      acc + (file.size * (file.downloadCount || 0)), 0)
+
+    console.log('\nBandwidth Usage Statistics:')
+    console.log(yellow('Total Downloads: ') + totalDownloads)
+    console.log(yellow('Total Bandwidth Used: ') + byteToSize(totalBandwidth))
+    console.log(yellow('Average Bandwidth per Download: ') + 
+      byteToSize(totalDownloads > 0 ? totalBandwidth / totalDownloads : 0))
+
+  } catch (error: any) {
+    console.log(red(error.message))
+    process.exit(0)
+  }
+} 

--- a/src/Commands/cost-estimate.ts
+++ b/src/Commands/cost-estimate.ts
@@ -1,0 +1,60 @@
+import { yellow, red } from 'kleur'
+import { Spinner } from 'cli-spinner'
+import byteToSize from './utils/byteToSize'
+
+export default async function (size: string, options: any) {
+  try {
+    if (!size) {
+      throw new Error('Please provide a file size (e.g., 1GB, 500MB, 1TB)')
+    }
+
+    const spinner = new Spinner('Calculating cost estimate... %s')
+    spinner.start()
+
+    const sizeInBytes = parseSizeToBytes(size)
+    
+    const storageRatePerGBPerMonth = 0.1 
+    const bandwidthRatePerGB = 0.05 
+    
+    const sizeInGB = sizeInBytes / (1024 * 1024 * 1024)
+    const monthlyStorageCost = sizeInGB * storageRatePerGBPerMonth
+    const estimatedBandwidthCost = sizeInGB * bandwidthRatePerGB
+
+    spinner.stop()
+    process.stdout.clearLine(-1, () => {})
+    process.stdout.cursorTo(0)
+
+    console.log('\nCost Estimate for ' + yellow(size) + ' (' + byteToSize(sizeInBytes) + '):')
+    console.log(yellow('Monthly Storage Cost: ') + `$${monthlyStorageCost.toFixed(2)} USD`)
+    console.log(yellow('Estimated Bandwidth Cost: ') + `$${estimatedBandwidthCost.toFixed(2)} USD per full download`)
+    console.log(yellow('Total First Month Estimate: ') + `$${(monthlyStorageCost + estimatedBandwidthCost).toFixed(2)} USD`)
+
+  } catch (error: any) {
+    console.log(red(error.message))
+    process.exit(0)
+  }
+}
+
+function parseSizeToBytes(sizeString: string): number {
+  const units: { [key: string]: number } = {
+    'B': 1,
+    'KB': 1024,
+    'MB': 1024 * 1024,
+    'GB': 1024 * 1024 * 1024,
+    'TB': 1024 * 1024 * 1024 * 1024
+  }
+
+  const match = sizeString.match(/^(\d+(?:\.\d+)?)\s*([KMGT]?B)$/i)
+  if (!match) {
+    throw new Error('Invalid size format. Please use format like 1GB, 500MB, 1TB')
+  }
+
+  const size = parseFloat(match[1])
+  const unit = match[2].toUpperCase()
+
+  if (!units[unit]) {
+    throw new Error('Invalid unit. Use B, KB, MB, GB, or TB')
+  }
+
+  return size * units[unit]
+} 

--- a/src/Commands/index.ts
+++ b/src/Commands/index.ts
@@ -17,6 +17,10 @@ import importWallet from './import-wallet'
 import revokeAccess from './revoke-access'
 import resetPassword from './reset-password'
 import uploadEncrypted from './upload-encrypted'
+import storageStats from './storage-stats'
+import quotaUsage from './quota-usage'
+import bandwidthUsage from './bandwidth-usage'
+import costEstimate from './cost-estimate'
 
 const widgets = new Command('lighthouse-web3')
 
@@ -157,6 +161,27 @@ widgets
   .command('get-uploads')
   .description('Get details of file uploaded')
   .action(getUploads)
+
+widgets
+  .command('storage-stats')
+  .description('Show detailed storage statistics')
+  .action(storageStats)
+
+widgets
+  .command('quota-usage')
+  .description('Show storage quota usage')
+  .action(quotaUsage)
+
+widgets
+  .command('bandwidth-usage')
+  .description('Show bandwidth usage')
+  .action(bandwidthUsage)
+
+widgets
+  .command('cost-estimate')
+  .argument('<size>', 'Size to estimate (e.g., 1GB, 500MB, 1TB)')
+  .description('Estimate storage cost')
+  .action(costEstimate)
 
 widgets.addHelpText(
   'after',

--- a/src/Commands/quota-usage.ts
+++ b/src/Commands/quota-usage.ts
@@ -1,0 +1,42 @@
+import { yellow, red } from 'kleur'
+import { Spinner } from 'cli-spinner'
+import lighthouse from '../Lighthouse'
+import byteToSize from './utils/byteToSize'
+import { config } from './utils/getNetwork'
+
+export default async function (data: any, options: any) {
+  try {
+    if (!config.get('LIGHTHOUSE_GLOBAL_API_KEY')) {
+      throw new Error('API key not found. Please set up your API key first.')
+    }
+
+    const spinner = new Spinner('Fetching quota information... %s')
+    spinner.start()
+
+    const response = await lighthouse.getBalance(
+      config.get('LIGHTHOUSE_GLOBAL_API_KEY') as string
+    )
+
+    spinner.stop()
+    process.stdout.clearLine(-1, () => {})
+    process.stdout.cursorTo(0)
+
+    const usagePercentage = (response.data.dataUsed / response.data.dataLimit) * 100
+
+    console.log('\nQuota Usage:')
+    console.log(yellow('Total Quota: ') + byteToSize(response.data.dataLimit))
+    console.log(yellow('Used Quota: ') + byteToSize(response.data.dataUsed))
+    console.log(yellow('Remaining: ') + byteToSize(response.data.dataLimit - response.data.dataUsed))
+    
+    const barWidth = 30
+    const filledWidth = Math.round((usagePercentage / 100) * barWidth)
+    const bar = '█'.repeat(filledWidth) + '░'.repeat(barWidth - filledWidth)
+    
+    console.log(yellow('\nUsage Progress:'))
+    console.log(`${bar} ${usagePercentage.toFixed(2)}%`)
+
+  } catch (error: any) {
+    console.log(red(error.message))
+    process.exit(0)
+  }
+} 

--- a/src/Commands/storage-stats.ts
+++ b/src/Commands/storage-stats.ts
@@ -1,0 +1,44 @@
+import { yellow, red } from 'kleur'
+import { Spinner } from 'cli-spinner'
+import lighthouse from '../Lighthouse'
+import byteToSize from './utils/byteToSize'
+import { config } from './utils/getNetwork'
+
+export default async function (data: any, options: any) {
+  try {
+    if (!config.get('LIGHTHOUSE_GLOBAL_API_KEY')) {
+      throw new Error('API key not found. Please set up your API key first.')
+    }
+
+    const spinner = new Spinner('Fetching storage statistics... %s')
+    spinner.start()
+
+    const balanceResponse = await lighthouse.getBalance(
+      config.get('LIGHTHOUSE_GLOBAL_API_KEY') as string
+    )
+
+    const uploadsResponse = await lighthouse.getUploads(
+      config.get('LIGHTHOUSE_GLOBAL_API_KEY') as string
+    )
+
+    spinner.stop()
+    process.stdout.clearLine(-1, () => {})
+    process.stdout.cursorTo(0)
+
+    const totalFiles = uploadsResponse.data.totalFiles
+    const totalSize = uploadsResponse.data.fileList.reduce((acc: number, file: any) => acc + file.size, 0)
+    const averageFileSize = totalFiles > 0 ? totalSize / totalFiles : 0
+
+    console.log('\nStorage Statistics:')
+    console.log(yellow('Total Storage Limit: ') + byteToSize(balanceResponse.data.dataLimit))
+    console.log(yellow('Total Storage Used: ') + byteToSize(balanceResponse.data.dataUsed))
+    console.log(yellow('Storage Remaining: ') + byteToSize(balanceResponse.data.dataLimit - balanceResponse.data.dataUsed))
+    console.log(yellow('Storage Usage %: ') + ((balanceResponse.data.dataUsed / balanceResponse.data.dataLimit) * 100).toFixed(2) + '%')
+    console.log(yellow('Total Files: ') + totalFiles)
+    console.log(yellow('Average File Size: ') + byteToSize(averageFileSize))
+
+  } catch (error: any) {
+    console.log(red(error.message))
+    process.exit(0)
+  }
+} 


### PR DESCRIPTION
Added new CLI commands for storage management:
- storage-stats: Show detailed storage statistics
- quota-usage: Display storage quota usage
- bandwidth-usage: Show bandwidth usage statistics
- cost-estimate: Calculate storage cost estimates

These commands enhance storage monitoring and cost management capabilities.