### PR TITLE
feat: add usage-stats command to display comprehensive account statistics and storage metrics

### DIFF
--- a/src/Commands/index.ts
+++ b/src/Commands/index.ts
@@ -17,6 +17,8 @@ import importWallet from './import-wallet'
 import revokeAccess from './revoke-access'
 import resetPassword from './reset-password'
 import uploadEncrypted from './upload-encrypted'
+import usageStats from './usage-stats'
+
 
 const widgets = new Command('lighthouse-web3')
 
@@ -157,6 +159,11 @@ widgets
   .command('get-uploads')
   .description('Get details of file uploaded')
   .action(getUploads)
+
+widgets
+  .command('usage-stats')
+  .description('Get usage stats')
+  .action(usageStats)
 
 widgets.addHelpText(
   'after',

--- a/src/Commands/usage-stats.ts
+++ b/src/Commands/usage-stats.ts
@@ -1,0 +1,37 @@
+import { green, yellow, red, cyan } from 'kleur'
+import { config } from './utils/getNetwork'
+import bytesToSize from './utils/byteToSize'
+import lighthouse from '../Lighthouse'
+import { lighthouseConfig } from '../lighthouse.config'
+
+export default async function () {
+  try {
+    const apiKey = config.get('LIGHTHOUSE_GLOBAL_API_KEY') as string
+    if (!apiKey) {
+      throw new Error(
+        'Please create an API key first using the "api-key" command.'
+      )
+    }
+
+    const balance = (await lighthouse.getBalance(apiKey)).data
+
+    const uploads = (await lighthouse.getUploads(apiKey)).data
+    const numberOfFiles = uploads.fileList.length
+    const totalSizeInBytes = uploads.fileList.reduce(
+      (acc, file) => acc + parseInt(file.fileSizeInBytes),
+      0
+    )
+    const totalSize = bytesToSize(totalSizeInBytes)
+
+    console.log(cyan('\r\nLighthouse Account Stats'))
+    console.log('------------------------')
+    console.log(
+      `${yellow('Account Balance:')}\t${green(bytesToSize(balance.dataLimit))}`
+    )
+    console.log(`${yellow('Total Files:')}\t\t${green(numberOfFiles)}`)
+    console.log(`${yellow('Total Storage Used:')}\t${green(totalSize)}`)
+  } catch (error: any) {
+    console.log(red(error.message))
+    process.exit(0)
+  }
+}


### PR DESCRIPTION
# Add usage-stats Command

## Description
Added a new `usage-stats` command that provides a clean summary of user's Lighthouse account statistics. The command displays key metrics in an easy-to-read format

## Features
- Account Balance in human-readable format (converted from bytes)
- Total number of files stored
- Total storage used

## Usage
```bash
lighthouse-web3 usage-stats
```