### PR TITLE
Fix: Correct response data indexing for saveShards function

### DIFF
--- a/src/Lighthouse/uploadEncrypted/encrypt/text/browser.ts
+++ b/src/Lighthouse/uploadEncrypted/encrypt/text/browser.ts
@@ -51,7 +51,7 @@ export default async (
 
     const { error } = await saveShards(
       publicKey,
-      responseData.Hash,
+      responseData[0].Hash,
       signedMessage,
       keyShards
     )


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix response data indexing in `saveShards` function call

- Change from `responseData.Hash` to `responseData[0].Hash`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Response Data"] --> B["Incorrect: responseData.Hash"]
  A --> C["Correct: responseData[0].Hash"]
  C --> D["saveShards Function"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>browser.ts</strong><dd><code>Fix response data array indexing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Lighthouse/uploadEncrypted/encrypt/text/browser.ts

<ul><li>Fix indexing of response data from <code>responseData.Hash</code> to <br><code>responseData[0].Hash</code><br> <li> Correct array access pattern for hash extraction</ul>


</details>


  </td>
  <td><a href="https://github.com/lighthouse-web3/lighthouse-package/pull/137/files#diff-8ac8b048876083ff260e9f9692dcbe64a1b5375fb469571e76d89ac83d21168d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

